### PR TITLE
style: Add new hero section with animated 'Zymo Ownership steps' to Buy page

### DIFF
--- a/src/components/buycomponent/Card.jsx
+++ b/src/components/buycomponent/Card.jsx
@@ -63,10 +63,15 @@ const Card = ({ car }) => {
           <p className="text-xs text-gray-500 text-right">Avg. Ex-Showroom price</p>
         </div>
         <Link to={`/buy/car-details/${car.carId}`} state={{ car }} className="mt-2">
-          <button className="w-20 h-10 rounded-lg bg-[#faffa4] flex items-center justify-center hover:bg-[#dff566] transition-colors">
-            <span className="fa-solid fa-arrow-right text-gray-800"></span>
+          <button className="w-20 h-10 rounded-lg bg-[#faffa4] flex items-center justify-center overflow-hidden group hover:bg-[#303030] hover:border-appColor hover:border-2 transition-colors">
+            <span className="relative flex items-center justify-center w-5 h-5 text-darkGrey2 group-hover:text-appColor">
+              <span className="group-hover:animate-arrow-loop transition-transform">
+                <i className="fa-solid fa-arrow-right"></i>
+              </span>
+            </span>
           </button>
         </Link>
+
       </div>
     </div>
   );

--- a/src/components/buycomponent/MorphingText.jsx
+++ b/src/components/buycomponent/MorphingText.jsx
@@ -1,0 +1,34 @@
+import { motion, AnimatePresence } from "framer-motion";
+
+export default function MorphingText({ text, className }) {
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key={text}
+        initial="hidden"
+        animate="visible"
+        exit="exit"
+        variants={{
+          hidden: {},
+          visible: { transition: { staggerChildren: 0.03 } },
+          exit: { transition: { staggerChildren: 0.03 } },
+        }}
+        className={`flex space-x-1 ${className}`}
+      >
+        {text.split("").map((char, i) => (
+          <motion.span
+            key={char + i}
+            variants={{
+              hidden: { opacity: 0, scaleY: 0, y: 20 },
+              visible: { opacity: 1, scaleY: 1, y: 0, transition: { duration: 0.3 } },
+              exit: { opacity: 0, scaleY: 0, y: -20, transition: { duration: 0.2 } },
+            }}
+            className="inline-block origin-bottom"
+          >
+            {char === " " ? "\u00A0" : char}
+          </motion.span>
+        ))}
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/src/components/buycomponent/TestOwnership.jsx
+++ b/src/components/buycomponent/TestOwnership.jsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import MorphingText from "./MorphingText";
+import WordAnimation from "./WordAnimation";
+
+const steps = [
+  {
+    title: "Rent an EV",
+    desc: "Start your EV journey by renting a vehicle for a few days. Experience the feel, features, and form factor without any commitment.",
+  },
+  {
+    title: "Live with it",
+    desc: "Drive it like you own it - daily commutes, grocery runs, weekend plans. See how seamlessly an EV fits into your lifestyle.",
+  },
+  {
+    title: "Drive it",
+    desc: "Test the EV on real roads, not just test tracks. Assess acceleration, handling, ride comfort, and cabin tech on your terms.",
+  },
+  {
+    title: "Charge it",
+    desc: "Experience firsthand how and where to charge. Understand charging times, range planning, and the actual ease of living electric.",
+  },
+  {
+    title: "Get performance data",
+    desc: "Receive personalized insights based on your driving habits — efficiency, battery usage, costs saved, and carbon footprint reduced.",
+  },
+  {
+    title: "Apply rental credits",
+    desc: "Loved it? Redeem a portion of your rental fees as credits towards your EV purchase. Zymo rewards real-world trials.",
+  },
+  {
+    title: "Purchase EV",
+    desc: "Buy with full confidence. You've driven, lived, and tested it — now make it yours, knowing exactly what you're getting into.",
+  },
+];
+
+export default function TestOwnership() {
+  const [index, setIndex] = useState(0);
+  const isFinalStep = index >= steps.length - 1;
+
+  useEffect(() => {
+    const delay = isFinalStep ? 6000 : 4000;
+    const timer = setTimeout(() => {
+      const nextIndex = isFinalStep ? 0 : index + 2;
+      setIndex(nextIndex);
+    }, delay);
+    return () => clearTimeout(timer);
+  }, [index, isFinalStep]);
+
+  const current = steps[index];
+  const next = steps[index + 1];
+
+  return (
+    <div className="relative h-screen w-full bg-[#212121] text-white px-10 sm:px-20 flex items-center justify-center">
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={index}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.6 }}
+          className={`w-full max-w-[1200px] ${
+            isFinalStep
+              ? "flex flex-col items-center justify-center text-center gap-6"
+              : "flex flex-col items-center gap-10 -mt-20"
+          }`}
+        >
+          {isFinalStep ? (
+            (() => {
+              const final = steps[steps.length - 1];
+              return (
+                <div className="flex flex-col items-center justify-center text-center -mt-32">
+                  <span className="lg:text-2xl tracking-widest text-appColor font-semibold">07</span>
+                  <MorphingText
+                    text={final.title}
+                    className="text-4xl lg:text-7xl font-extrabold bg-gradient-to-r from-appColor to-yellow-500 bg-clip-text text-transparent"
+                  />
+                  <WordAnimation
+                    text={final.desc}
+                    className="text-base lg:text-xl max-w-2xl mt-4 text-white justify-center"
+                  />
+                </div>
+              );
+            })()
+          ) : (
+            <>
+              <div className="flex flex-col lg:absolute top-16 left-52">
+                <span className="lg:text-lg text-white">0{index + 1}</span>
+                <WordAnimation text={current.title} className="lg:text-6xl text-[2rem] font-bold lg:mb-10 mb-5 leading-9" />
+                <WordAnimation text={current.desc} className="lg:text-xl text-base max-w-md" />
+              </div>
+              {next && (
+                <div className="flex flex-col lg:absolute bottom-44 right-60">
+                  <span className="lg:text-lg text-white">0{index + 2}</span>
+                  <WordAnimation text={next.title} className="lg:text-6xl text-[2rem] font-bold lg:mb-10 mb-5 leading-9" />
+                  <WordAnimation text={next.desc} className="lg:text-xl text-base max-w-md" />
+                </div>
+              )}
+            </>
+          )}
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/buycomponent/WordAnimation.jsx
+++ b/src/components/buycomponent/WordAnimation.jsx
@@ -1,0 +1,34 @@
+import { motion } from "framer-motion";
+
+export default function WordAnimation({ text, className = "" }) {
+  return (
+    <motion.div
+      key={text}
+      initial="hidden"
+      animate="visible"
+      exit="hidden"
+      variants={{
+        visible: { transition: { staggerChildren: 0.04 } },
+        hidden: { transition: { staggerChildren: 0.02 } },
+      }}
+      className={`flex flex-wrap ${className}`}
+    >
+      {text.split(" ").map((word, i) => (
+        <motion.span
+          key={word + i}
+          variants={{
+            hidden: { opacity: 0, y: 10 },
+            visible: {
+              opacity: 1,
+              y: 0,
+              transition: { duration: 0.3, ease: "easeOut" },
+            },
+          }}
+          className="mr-2 md:mr-3 inline-block"
+        >
+          {word}
+        </motion.span>
+      ))}
+    </motion.div>
+  );
+}

--- a/src/pages/Buy/NearestCar.jsx
+++ b/src/pages/Buy/NearestCar.jsx
@@ -10,6 +10,7 @@ import { collection, getDocs } from "firebase/firestore";
 import { webDB } from "../../utils/firebase";
 import { Helmet } from "react-helmet-async";
 import LoadingCard from '../../components/buycomponent/LoadingCard'
+import TestOwnership from "../../components/buycomponent/TestOwnership";
   
 const NearestCar = ({ title }) => {
   const navigate = useNavigate();
@@ -90,9 +91,9 @@ const NearestCar = ({ title }) => {
         {/* Dark overlay */}
         {/* <div className="absolute inset-0 bg-black/50"></div> */}
         
-        <img src="/images/BuyCars/Electric_Hero_yellow.png" alt="Yellow Hero" 
+        {/* <img src="/images/BuyCars/Electric_Hero_yellow.png" alt="Yellow Hero" 
           className="absolute w-full sm:w-screen h-full object-cover z-0"
-         />
+         /> */}
         {/* <div 
           className="absolute inset-0 w-full h-full"
           style={{
@@ -102,22 +103,7 @@ const NearestCar = ({ title }) => {
             backgroundRepeat: 'no-repeat'
           }}
         /> */}
-
-        {/* Content container */}
-        <div className="relative z-10 h-full container mx-auto px-4 py-4">
-          <div className="flex flex-col sm:flex-row justify-center items-center sm:items-start h-full mt-48 sm:mt-10 pr-0 sm:mr-11 sm:pr-8">
-            {/* <div className="space-y-4"> */}
-            <div>
-              <h1 className="text-xl sm:text-5xl font-bold text-white opacity-0 animate-slide-up">
-                Your EV Trial, Supercharged!
-              </h1>
-              {/* <p className="text-gray-200 text-lg max-w-xl opacity-0 animate-slide-up-delayed">
-                Find your perfect electric vehicle today
-              </p> */}
-            </div>
-
-          </div>
-        </div>
+        <TestOwnership />
       </div>
 
       {/* <Filter setFilterCar={setFilteredCars} /> */}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,11 +22,18 @@ export default {
         slideUp: {
           '0%': { transform: 'translateY(100px)', opacity: '0' },
           '100%': { transform: 'translateY(0)', opacity: '1' },
-        }
+        },
+        arrowLoop: {
+          '0%': { transform: 'translateX(0)', opacity: 1 },
+          '40%': { transform: 'translateX(100%)', opacity: 0 },
+          '41%': { transform: 'translateX(-100%)', opacity: 0 },
+          '100%': { transform: 'translateX(0)', opacity: 1 },
+        },
       },
       animation: {
         'slide-up': 'slideUp 1s ease-out forwards',
         'slide-up-delayed': 'slideUp 1s ease-out 0.5s forwards',
+        'arrow-loop': 'arrowLoop 0.8s ease-in-out',
       }
     },
   },


### PR DESCRIPTION
- Added a new hero section to the Buy page showcasing the EV ownership journey steps using text animations and smooth transitions.
- Also modifed the button hover styles for the cards. 
- The hero section could benefit from a background (e.g., gradient, image, or texture) to add more visual depth open to design feedback here.